### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,7 @@ After that, you can import the new directive using 'image-load' tag.
 
 This directive just work with .jpg, .gif or .png images. To correct the image orientation just add `image-load` to a parent `<div>` in your image. See the example below:
 ```html
-<div data-ng-click="openPhotoUploadModal()" class="div80_80 ng-pristine ng-valid" height="80" width="80" ng-model="photo" image-load>
-    <img src="http://localhost/statics//upload/users/profile/photo/SEJTAZ/image.jpg" class="user photo-img img80_80 ng-pristine ng-valid" ng-model="account.photo">
+<div data-ng-click="openPhotoUploadModal()" class="div80_80" height="80" width="80" ng-model="photo" image-load>
+    <img src="http://localhost/statics//upload/users/profile/photo/SEJTAZ/image.jpg" class="user photo-img img80_80" ng-model="account.photo">
 </div>
 ```
-## Options
-You can set some options to image render as:
-- *Height: set the height of the generated canvas just imputing the `height` attribute to the `<div>`
-- *Width: set the width of the generated canvas just imputing the `width` attribute to the `<div>`
-- *Class: setting the `class` attribute to the `<div>`, the directive replaces automatically the default style for the canvas canvas.


### PR DESCRIPTION
Removed `ng-pristine ng-valid` classes added by AngularJS in run-time.
